### PR TITLE
Synchro dendro3 ↔ staging + enregistrement de l'app mobile

### DIFF
--- a/backend/gn_module_psdrf/blueprint.py
+++ b/backend/gn_module_psdrf/blueprint.py
@@ -32,7 +32,8 @@ from .disp_placette_liste import disp_placette_liste_add
 from .bddToExcel import bddToExcel
 from .schemas.cycles import ConciseCycleSchema
 from .schemas.essences import EssenceSchema
-from .tasks import test_celery, insert_or_update_data, fetch_dispositif_data, fetch_updated_data
+from .tasks import test_celery, insert_or_update_data, fetch_dispositif_data, fetch_updated_data, fetch_dispositif_data_merged
+from .pr_psdrf_staging_functions.models_staging import TDendro3SyncLog
 from .helpers.parse_date import parse_iso_datetime
 
 # Modèle standard GeoNature des applications mobiles : source unique de vérité
@@ -742,6 +743,109 @@ def get_dispositif_result(task_id):
         return jsonify({'status': 'incomplete', 'message': 'Task is not finished yet.'}), 202
 
 
+# ---------------------------------------------------------------------------
+# Brique 1 — Pull fusionné prod + staging (reprise/continuation de saisie).
+# Même patron async que /dispositif-complet (202 + status + result) et même
+# format de réponse, de sorte que l'app dendro3 réutilise le même mapper.
+# ---------------------------------------------------------------------------
+
+@blueprint.route('/dispositif-complet-staging/<int:id_dispositif>', methods=['GET'])
+def get_dispositif_complet_staging(id_dispositif):
+    logger.info(f"Received request to start MERGED task for dispositif ID: {id_dispositif}")
+    task = fetch_dispositif_data_merged.delay(id_dispositif)
+    logger.info(f"Merged task {task.id} started for dispositif ID: {id_dispositif}")
+    return jsonify({'task_id': task.id}), 202
+
+
+@blueprint.route('/dispositif-complet-staging/status/<task_id>', methods=['GET'])
+def get_dispositif_staging_status(task_id):
+    logger.info(f"Checking status of merged task ID: {task_id}")
+    task = fetch_dispositif_data_merged.AsyncResult(task_id)
+    if task.state in ['PENDING', 'STARTED']:
+        return jsonify({'state': task.state}), 202
+    elif task.state == 'FAILURE':
+        logger.error(f"Merged task {task_id} failed with error: {task.info}")
+        return jsonify({'state': task.state, 'error': str(task.info)}), 500
+    elif task.state == 'SUCCESS':
+        return jsonify({'state': task.state}), 200
+    else:
+        return jsonify({'state': task.state}), 202
+
+
+@blueprint.route('/dispositif-complet-staging/result/<task_id>', methods=['GET'])
+def get_dispositif_staging_result(task_id):
+    logger.info(f"Retrieving result for merged task ID: {task_id}")
+    task = fetch_dispositif_data_merged.AsyncResult(task_id)
+    if task.status == 'SUCCESS':
+        return jsonify(task.result), 200
+    elif task.status == 'FAILURE':
+        logger.error(f"Retrieving merged result failed for task ID: {task_id}, Error: {task.info}")
+        return jsonify({'error': str(task.info)}), 500
+    else:
+        return jsonify({'status': 'incomplete', 'message': 'Task is not finished yet.'}), 202
+
+
+# ---------------------------------------------------------------------------
+# Brique 3 — État des placettes : dernier appareil/utilisateur ayant saisi en
+# staging sur chaque placette du dispositif (tableau de bord multi-édition).
+# ---------------------------------------------------------------------------
+
+@blueprint.route('/dispositif-placettes-state/<int:id_dispositif>', methods=['GET'])
+def get_dispositif_placettes_state(id_dispositif):
+    """Renvoie, par placette, le dernier log de synchro (qui/quel appareil/quand).
+
+    Réponse : {'status': 'success', 'data': [ {id_placette, id_dispositif,
+    device, id_role, identifiant, nom_complet, synced_at}, ... ]}.
+    """
+    # Dernier synced_at par placette pour ce dispositif.
+    last_per_placette = (
+        DB.session.query(
+            TDendro3SyncLog.id_placette.label('id_placette'),
+            func.max(TDendro3SyncLog.synced_at).label('last_synced_at'),
+        )
+        .filter(TDendro3SyncLog.id_dispositif == id_dispositif)
+        .group_by(TDendro3SyncLog.id_placette)
+        .subquery()
+    )
+
+    rows = (
+        DB.session.query(TDendro3SyncLog, User)
+        .join(
+            last_per_placette,
+            (TDendro3SyncLog.id_placette == last_per_placette.c.id_placette)
+            & (TDendro3SyncLog.synced_at == last_per_placette.c.last_synced_at),
+        )
+        .outerjoin(User, User.id_role == TDendro3SyncLog.id_role)
+        .filter(TDendro3SyncLog.id_dispositif == id_dispositif)
+        .all()
+    )
+
+    data = []
+    seen = set()
+    for log, user in rows:
+        # Garde-fou contre d'éventuels ex-aequo de synced_at sur une placette.
+        if log.id_placette in seen:
+            continue
+        seen.add(log.id_placette)
+        nom_complet = None
+        identifiant = None
+        if user is not None:
+            identifiant = getattr(user, 'identifiant', None)
+            prenom = getattr(user, 'prenom_role', None) or ''
+            nom = getattr(user, 'nom_role', None) or ''
+            nom_complet = (prenom + ' ' + nom).strip() or None
+        data.append({
+            'id_placette': log.id_placette,
+            'id_dispositif': log.id_dispositif,
+            'device': log.device,
+            'id_role': log.id_role,
+            'identifiant': identifiant,
+            'nom_complet': nom_complet,
+            'synced_at': log.synced_at.isoformat() if log.synced_at else None,
+        })
+
+    return jsonify({'status': 'success', 'data': data}), 200
+
 
 @blueprint.route('/dispositif-cycles/<int:id_dispositif>', methods=['GET'])
 def get_dispositif_cycles(id_dispositif):
@@ -793,8 +897,14 @@ def get_PSDRF_t_nomenclatures():
 @blueprint.route('/export_dispositif_from_dendro3', methods=['POST'])
 def export_dispositif():
     """
-    Receives a dispositif entity as JSON and exports it to the database.
-    Returns the number of added entities and that have updated
+    Receives a dispositif entity as JSON and exports it to the database (staging).
+    Returns the number of added/updated entities.
+
+    Brique 2 (traçabilité) : le payload accepte désormais, à la racine, deux
+    champs optionnels qui sont propagés tels quels à la tâche d'export :
+      - ``device`` (str) : nom/identifiant de l'appareil mobile ;
+      - ``id_role`` (int) : utilisateur ayant lancé la synchro.
+    La tâche insère une ligne par placette dans ``pr_psdrf_staging.t_dendro3_sync_log``.
     """
     data = request.get_json()
     

--- a/backend/gn_module_psdrf/migrations/a1b2c3d4e5f6_register_dendro3_mobile_app.py
+++ b/backend/gn_module_psdrf/migrations/a1b2c3d4e5f6_register_dendro3_mobile_app.py
@@ -1,0 +1,51 @@
+"""register dendro3 mobile app in gn_commons.t_mobile_apps
+
+dendro3 (application Flutter terrain PSDRF) est enregistrée dans la table
+standard GeoNature gn_commons.t_mobile_apps, qui devient la source unique de
+vérité pour la version et le chemin de l'APK. La route standard
+GET /gn_commons/t_mobile_apps et la route pont GET /psdrf/mobile-app lisent
+toutes deux cette ligne, sans duplication de la donnée.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 2115ba146beb
+Create Date: 2026-06-03
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "2115ba146beb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # version_code = Android versionCode courant (entier sous forme de chaîne).
+    #   C'est LE champ comparé par le client pour décider d'une mise à jour.
+    #   Pour publier une nouvelle version : bumper cette valeur ET déposer le
+    #   nouvel APK (voir relative_path_apk).
+    # relative_path_apk = chemin RELATIF au dossier {MEDIA_FOLDER}/mobile/
+    #   (le préfixe "mobile/" est ajouté par GeoNature à la construction d'URL).
+    #   Le binaire doit donc être déposé dans :
+    #   {MEDIA_FOLDER}/mobile/dendro3/dendro3-1.0.2.apk
+    op.execute(
+        """
+        INSERT INTO gn_commons.t_mobile_apps
+            (app_code, package, version_code, relative_path_apk)
+        VALUES
+            ('dendro3', 'org.reserves_naturelles.dendro3', '1', 'dendro3/dendro3-1.0.2.apk')
+        ON CONFLICT (app_code) DO UPDATE SET
+            package = EXCLUDED.package,
+            version_code = EXCLUDED.version_code,
+            relative_path_apk = EXCLUDED.relative_path_apk
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DELETE FROM gn_commons.t_mobile_apps WHERE app_code = 'dendro3'
+        """
+    )

--- a/backend/gn_module_psdrf/migrations/b2c3d4e5f6a7_create_dendro3_sync_log.py
+++ b/backend/gn_module_psdrf/migrations/b2c3d4e5f6a7_create_dendro3_sync_log.py
@@ -1,0 +1,55 @@
+"""create pr_psdrf_staging.t_dendro3_sync_log
+
+Journal de synchronisation dendro3 : trace, par placette synchronisée, quel
+appareil (device) et quel utilisateur (id_role) ont saisi, et quand (synced_at).
+Alimente la traçabilité « 1 mobile = 1 placette » et la route d'état des
+placettes (GET /psdrf/dispositif-placettes-state/<id_dispositif>).
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-05
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+SCHEMA_STAGING = "pr_psdrf_staging"
+
+
+def upgrade():
+    # Le schéma pr_psdrf_staging est normalement créé hors Alembic par
+    # create_pr_psdrf_staging_schema.sql. Garde-fou pour rendre cette migration
+    # autonome : la table de log n'a aucune FK vers les tables miroir staging.
+    op.execute("CREATE SCHEMA IF NOT EXISTS " + SCHEMA_STAGING)
+    op.create_table(
+        "t_dendro3_sync_log",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("id_dispositif", sa.Integer(), nullable=True),
+        sa.Column("id_placette", sa.Integer(), nullable=True),
+        sa.Column("device", sa.Text(), nullable=True),
+        sa.Column("id_role", sa.Integer(), nullable=True),
+        sa.Column("synced_at", sa.DateTime(), nullable=True),
+        schema=SCHEMA_STAGING,
+    )
+    # Index pour la route d'état des placettes (dernier log par placette).
+    op.create_index(
+        "ix_dendro3_sync_log_disp_placette",
+        "t_dendro3_sync_log",
+        ["id_dispositif", "id_placette"],
+        schema=SCHEMA_STAGING,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_dendro3_sync_log_disp_placette",
+        table_name="t_dendro3_sync_log",
+        schema=SCHEMA_STAGING,
+    )
+    op.drop_table("t_dendro3_sync_log", schema=SCHEMA_STAGING)

--- a/backend/gn_module_psdrf/pr_psdrf_staging_functions/merge_prod_staging.py
+++ b/backend/gn_module_psdrf/pr_psdrf_staging_functions/merge_prod_staging.py
@@ -1,0 +1,119 @@
+"""Fusion prod + staging d'un dispositif PSDRF sérialisé.
+
+Les deux dictionnaires d'entrée proviennent de schémas Marshmallow miroirs
+(``DispositifSchema`` côté prod, ``DispositifStagingSchema`` côté staging) : pour
+une même entité ils exposent les MÊMES clés, car les modèles prod et staging
+sont des miroirs colonne à colonne. La fusion se fait donc niveau par niveau,
+par identifiant :
+
+- entité présente en prod ET staging    -> la valeur staging écrase la valeur
+  prod (champ à champ), puis les enfants sont fusionnés récursivement ;
+- entité présente seulement en prod      -> conservée telle quelle ;
+- entité présente seulement en staging   -> ajoutée (création terrain), ses
+  enfants étant fusionnés contre une liste prod vide.
+
+Le format de sortie est STRICTEMENT celui de ``/psdrf/dispositif-complet`` : pour
+une entité fusionnée on part toujours du dictionnaire prod et on n'y réinjecte
+que des clés déjà présentes ; on n'introduit jamais de clé absente de prod.
+
+Limite connue : les suppressions faites côté mobile ne sont PAS matérialisées
+dans le schéma staging (la fonction d'import supprime la ligne staging sans
+laisser de tombstone). La fusion est donc « prod ∪ staging-override » : une
+entité supprimée sur le terrain mais encore présente en prod ressort en version
+prod.
+"""
+
+# Arbre de fusion. Chaque entrée : clé_de_liste -> (clé_identifiant, sous-enfants)
+_CHILDREN = {
+    "placettes": ("id_placette", {
+        "arbres": ("id_arbre", {
+            "arbres_mesures": ("id_arbre_mesure", {}),
+        }),
+        "bmsSup30": ("id_bm_sup_30", {
+            "bm_sup_30_mesures": ("id_bm_sup_30_mesure", {}),
+        }),
+        "reperes": ("id_repere", {}),
+    }),
+    "cycles": ("id_cycle", {
+        "corCyclesPlacettes": ("id_cycle_placette", {
+            "regenerations": ("id_regeneration", {}),
+            "transects": ("id_transect", {}),
+        }),
+    }),
+}
+
+
+def _merge_entity(prod, staging, children):
+    """Fusionne une entité : staging écrase prod champ à champ, enfants fusionnés."""
+    out = dict(prod)
+    child_keys = set(children)
+    for key, value in staging.items():
+        if key in child_keys:
+            continue
+        if key in out:  # ne jamais introduire de clé absente de prod
+            out[key] = value
+    for list_key, (id_key, sub_children) in children.items():
+        out[list_key] = _merge_list(
+            prod.get(list_key) or [],
+            staging.get(list_key) or [],
+            id_key,
+            sub_children,
+        )
+    return out
+
+
+def _new_entity_from_staging(staging, children):
+    """Construit une entité « création terrain » à partir du seul staging."""
+    out = dict(staging)
+    for list_key, (id_key, sub_children) in children.items():
+        out[list_key] = _merge_list(
+            [],
+            staging.get(list_key) or [],
+            id_key,
+            sub_children,
+        )
+    return out
+
+
+def _merge_list(prod_list, staging_list, id_key, children):
+    """Fusionne deux listes d'entités par identifiant (str), ordre prod préservé."""
+    staging_by_id = {}
+    for item in staging_list:
+        ident = item.get(id_key)
+        if ident is not None:
+            staging_by_id[str(ident)] = item
+
+    merged = []
+    consumed = set()
+    for prod_item in prod_list:
+        ident = prod_item.get(id_key)
+        skey = str(ident) if ident is not None else None
+        staging_item = staging_by_id.get(skey) if skey is not None else None
+        if staging_item is None:
+            merged.append(prod_item)
+        else:
+            consumed.add(skey)
+            merged.append(_merge_entity(prod_item, staging_item, children))
+
+    # Entités présentes uniquement en staging (créations terrain), ordre staging.
+    for staging_item in staging_list:
+        ident = staging_item.get(id_key)
+        skey = str(ident) if ident is not None else None
+        if skey is not None and skey in consumed:
+            continue
+        merged.append(_new_entity_from_staging(staging_item, children))
+
+    return merged
+
+
+def merge_dispositif_prod_staging(prod_data, staging_data):
+    """Fusionne le dispositif prod (dict) avec sa version staging (dict ou None).
+
+    :param prod_data: dispositif sérialisé par ``DispositifSchema`` (prod).
+    :param staging_data: dispositif sérialisé par ``DispositifStagingSchema``
+        (staging) ou ``None`` / ``{}`` si aucune saisie en staging.
+    :return: dict au format identique à ``/psdrf/dispositif-complet``.
+    """
+    if not staging_data:
+        return prod_data
+    return _merge_entity(prod_data, staging_data, _CHILDREN)

--- a/backend/gn_module_psdrf/pr_psdrf_staging_functions/models_staging.py
+++ b/backend/gn_module_psdrf/pr_psdrf_staging_functions/models_staging.py
@@ -310,3 +310,21 @@ class TTransectsStaging (DB.Model):
     updated_at = DB.Column('updated_at', DB.DateTime)
 
     cor_cycles_placettes = DB.relationship('CorCyclesPlacettesStaging', foreign_keys=id_cycle_placette, back_populates='transects')
+
+
+class TDendro3SyncLog(DB.Model):
+    """Journal de synchronisation dendro3 : trace quel appareil et quel
+    utilisateur ont saisi sur quelle placette, et quand.
+
+    Une ligne est insérée par placette synchronisée lors d'un export depuis
+    l'app mobile. Sert la règle « 1 mobile = 1 placette », la prévention de
+    multi-édition et l'écran de comparaison local <-> staging (Brique 3).
+    """
+    __tablename__ = "t_dendro3_sync_log"
+    __table_args__ = {'schema': SCHEMA_STAGING}
+    id = DB.Column('id', DB.Integer, primary_key=True)
+    id_dispositif = DB.Column('id_dispositif', DB.Integer)
+    id_placette = DB.Column('id_placette', DB.Integer)
+    device = DB.Column('device', DB.Text)
+    id_role = DB.Column('id_role', DB.Integer)
+    synced_at = DB.Column('synced_at', DB.DateTime, default=datetime.utcnow)

--- a/backend/gn_module_psdrf/tasks.py
+++ b/backend/gn_module_psdrf/tasks.py
@@ -24,7 +24,8 @@ from .models import (
 )
 from .schemas.dispositifs import DispositifSchema
 from .staging_schemas.dispositifs import DispositifStagingSchema
-from .pr_psdrf_staging_functions.models_staging import TDispositifsStaging
+from .pr_psdrf_staging_functions.models_staging import TDispositifsStaging, TDendro3SyncLog
+from .pr_psdrf_staging_functions.merge_prod_staging import merge_dispositif_prod_staging
 from .helpers.count_updates_and_creation import count_updates_and_creations
 
 from .pr_psdrf_staging_functions.insert_or_update_functions.insert_or_update_dispositif import insert_or_update_dispositif
@@ -144,10 +145,16 @@ def insert_or_update_data(self, data):
     counts_regeneration = {'created': 0, 'updated': 0, 'deleted': 0}
     counts_transect = {'created': 0, 'updated': 0, 'deleted': 0}
 
+    # Brique 2 — traçabilité : appareil + utilisateur ayant lancé cet export.
+    device = data.get('device')
+    id_role = data.get('id_role')
+    sync_log_count = 0
+
     try:
         with current_app.app_context():
             if 'id_dispositif' in data:
                 result = insert_or_update_dispositif(data, session)
+                id_dispositif = data.get('id_dispositif')
 
                 if 'cycles' in data:
                     for cycle_data in data['cycles']:
@@ -156,7 +163,18 @@ def insert_or_update_data(self, data):
                 if 'placettes' in data:
                     for placette_data in data['placettes']:
                         placette_result = insert_or_update_placette(placette_data, session)
-                    
+
+                        # Une ligne de log par placette synchronisée (qui/quel
+                        # appareil/quand) — alimente la route d'état des placettes.
+                        session.add(TDendro3SyncLog(
+                            id_dispositif=id_dispositif,
+                            id_placette=placette_data.get('id_placette'),
+                            device=device,
+                            id_role=id_role,
+                            synced_at=datetime.utcnow(),
+                        ))
+                        sync_log_count += 1
+
                         created_arbres_temp, counts_arbre_temp, counts_arbre_mesure_temp = insert_update_or_delete_arbre(placette_data, session)
                         created_arbres.extend(created_arbres_temp)
                         for key in counts_arbre_temp:
@@ -195,9 +213,10 @@ def insert_or_update_data(self, data):
                 'counts_bm': counts_bm, 
                 'counts_bm_mesure': counts_bm_mesure, 
                 'counts_repere': counts_repere, 
-                'counts_cor_cycle_placette': counts_cor_cycle_placette, 
-                'counts_regeneration': counts_regeneration, 
+                'counts_cor_cycle_placette': counts_cor_cycle_placette,
+                'counts_regeneration': counts_regeneration,
                 'counts_transect': counts_transect,
+                'sync_log_count': sync_log_count,
             }
         )
 
@@ -222,11 +241,42 @@ def insert_or_update_data(self, data):
         'counts_bm': counts_bm, 
         'counts_bm_mesure': counts_bm_mesure,
         'counts_repere': counts_repere, 
-        'counts_cor_cycle_placette': counts_cor_cycle_placette, 
-        'counts_regeneration': counts_regeneration, 
-        'counts_transect': counts_transect
+        'counts_cor_cycle_placette': counts_cor_cycle_placette,
+        'counts_regeneration': counts_regeneration,
+        'counts_transect': counts_transect,
+        'sync_log_count': sync_log_count,
     }
 
+
+
+def _query_dispositif_prod(id_dispositif):
+    """Charge un dispositif complet depuis la prod (pr_psdrf) avec toutes ses
+    relations préchargées. Requête partagée par ``fetch_dispositif_data`` et
+    ``fetch_dispositif_data_merged``."""
+    return (
+        DB.session.query(TDispositifs)
+        .filter(TDispositifs.id_dispositif == id_dispositif)
+        .options(
+            selectinload(TDispositifs.placettes).options(
+                selectinload(TPlacettes.arbres).options(
+                    selectinload(TArbres.arbres_mesures),
+                    joinedload(TArbres.essence),
+                ),
+                selectinload(TPlacettes.bmsSup30).options(
+                    selectinload(TBmSup30.bm_sup_30_mesures),
+                    joinedload(TBmSup30.essence),
+                ),
+                selectinload(TPlacettes.reperes),
+            ),
+            selectinload(TDispositifs.cycles).options(
+                selectinload(TCycles.corCyclesPlacettes).options(
+                    selectinload(CorCyclesPlacettes.regenerations),
+                    selectinload(CorCyclesPlacettes.transects),
+                ),
+            ),
+        )
+        .one()
+    )
 
 
 # Task to get all the data of a dispositif from the prod database
@@ -236,30 +286,7 @@ def fetch_dispositif_data(self, id_dispositif):
     try:
         with current_app.app_context():
             logger.info("Starting database query...")
-            query = (
-                DB.session.query(TDispositifs)
-                .filter(TDispositifs.id_dispositif == id_dispositif)
-                .options(
-                    selectinload(TDispositifs.placettes).options(
-                        selectinload(TPlacettes.arbres).options(
-                            selectinload(TArbres.arbres_mesures),
-                            joinedload(TArbres.essence),
-                        ),
-                        selectinload(TPlacettes.bmsSup30).options(
-                            selectinload(TBmSup30.bm_sup_30_mesures),
-                            joinedload(TBmSup30.essence),
-                        ),
-                        selectinload(TPlacettes.reperes),
-                    ),
-                    selectinload(TDispositifs.cycles).options(
-                        selectinload(TCycles.corCyclesPlacettes).options(
-                            selectinload(CorCyclesPlacettes.regenerations),
-                            selectinload(CorCyclesPlacettes.transects),
-                        ),
-                    ),
-                )
-                .one()
-            )
+            query = _query_dispositif_prod(id_dispositif)
             logger.info("Database query completed.")
             schema = DispositifSchema(many=False)
             logger.info("Starting serialization of data...")
@@ -269,6 +296,46 @@ def fetch_dispositif_data(self, id_dispositif):
             return {'status': 'SUCCESS', 'data': result}
     except Exception as e:
         logger.exception("Error during fetching dispositif data")
+        return {'status': 'FAILURE', 'data': str(e)}
+
+
+# Task to get the dispositif as a merge of prod + staging (Brique 1, le « pull »).
+@celery_app.task(bind=True, soft_time_limit=2400, time_limit=2600)
+def fetch_dispositif_data_merged(self, id_dispositif):
+    """Renvoie le dispositif complet FUSIONNÉ prod + staging.
+
+    Format de sortie STRICTEMENT identique à ``fetch_dispositif_data``
+    (``{'status': 'SUCCESS', 'data': <dispositif complet>}``) : l'app réutilise
+    le même mapper. Pour chaque entité (placettes, arbres, mesures, bms, reperes,
+    cycles, cor_cycles_placettes, regenerations, transects), la version staging
+    écrase la prod si elle existe ; sinon la valeur prod est conservée. Un
+    dispositif sans saisie staging ressort identique à la prod.
+    """
+    logger.info(f"[MERGE] Task started for dispositif ID: {id_dispositif}")
+    try:
+        with current_app.app_context():
+            # 1/ Dispositif complet depuis la prod (même requête que le download classique).
+            prod_query = _query_dispositif_prod(id_dispositif)
+            prod_data = DispositifSchema(many=False).dump(prod_query)
+
+            # 2/ Version staging (peut être absente : pas encore de saisie terrain).
+            staging_dispositif = (
+                DB.session.query(TDispositifsStaging)
+                .filter(TDispositifsStaging.id_dispositif == id_dispositif)
+                .first()
+            )
+            staging_data = (
+                DispositifStagingSchema(many=False).dump(staging_dispositif)
+                if staging_dispositif is not None
+                else None
+            )
+
+            # 3/ Fusion par id à chaque niveau (staging écrase prod).
+            merged = merge_dispositif_prod_staging(prod_data, staging_data)
+            logger.info(f"[MERGE] Merge completed for dispositif ID: {id_dispositif}")
+            return {'status': 'SUCCESS', 'data': merged}
+    except Exception as e:
+        logger.exception("Error during fetching merged dispositif data")
         return {'status': 'FAILURE', 'data': str(e)}
     
 

--- a/docs/dendro3-sync-staging.md
+++ b/docs/dendro3-sync-staging.md
@@ -1,0 +1,139 @@
+# Synchronisation dendro3 ↔ staging PSDRF — contrat backend
+
+Mise en œuvre des 3 briques décrites dans
+`dendro3/docs/prompt-psdrf-reprise-staging.md` : pull fusionné prod + staging,
+traçabilité appareil/utilisateur, état des placettes.
+
+## Fichiers créés / modifiés
+
+| Fichier | Nature | Rôle |
+|---|---|---|
+| `pr_psdrf_staging_functions/merge_prod_staging.py` | **créé** | Fusion par id (prod ∪ staging-override) d'un dispositif sérialisé. Fonction pure, testée hors BDD. |
+| `migrations/b2c3d4e5f6a7_create_dendro3_sync_log.py` | **créé** | Crée `pr_psdrf_staging.t_dendro3_sync_log` (+ index `(id_dispositif, id_placette)`). down_revision = `a1b2c3d4e5f6`. |
+| `pr_psdrf_staging_functions/models_staging.py` | modifié | Ajout du modèle `TDendro3SyncLog`. |
+| `tasks.py` | modifié | Helper `_query_dispositif_prod`, nouvelle tâche `fetch_dispositif_data_merged`, écriture du log dans `insert_or_update_data` (lecture `device`/`id_role`). |
+| `blueprint.py` | modifié | 3 routes pull fusionné + route d'état des placettes ; docstring export. |
+
+Aucune route ni tâche existante n'a changé de contrat (compat conservée).
+
+> Migration : `alembic upgrade head` (le schéma `pr_psdrf_staging` est garanti par
+> un `CREATE SCHEMA IF NOT EXISTS` ; la table de log n'a aucune FK vers les tables
+> miroir staging, elle est donc autonome).
+
+---
+
+## Brique 1 — Pull fusionné (reprise/continuation de saisie)
+
+Même patron asynchrone et **même format de réponse** que `/dispositif-complet`.
+
+| Étape | Méthode & chemin | Réponse |
+|---|---|---|
+| Lancer | `GET /psdrf/dispositif-complet-staging/<int:id_dispositif>` | `202` `{ "task_id": "<id>" }` |
+| Statut | `GET /psdrf/dispositif-complet-staging/status/<task_id>` | `202` `{ "state": "PENDING"\|"STARTED" }` · `200` `{ "state": "SUCCESS" }` · `500` `{ "state": "FAILURE", "error": "…" }` |
+| Résultat | `GET /psdrf/dispositif-complet-staging/result/<task_id>` | `200` `{ "status": "SUCCESS", "data": <dispositif complet fusionné> }` · `202` (pas fini) · `500` (erreur) |
+
+`data` a **strictement la même structure** que `/psdrf/dispositif-complet/result/<task_id>`
+(clés `placettes` → `arbres` → `arbres_mesures`, `bmsSup30` → `bm_sup_30_mesures`,
+`reperes` ; `cycles` → `corCyclesPlacettes` → `regenerations`, `transects`).
+→ même mapper et même insert local côté app.
+
+**Règle de fusion** (par `id`, à chaque niveau) :
+- entité en prod **et** staging → la version **staging écrase** la prod (champ à champ), enfants fusionnés récursivement ;
+- entité en prod seule → conservée (valeur prod) ;
+- entité en staging seule (création terrain) → ajoutée ;
+- aucun staging pour le dispositif → réponse = prod pur (identité).
+
+---
+
+## Brique 2 — Traçabilité appareil + utilisateur
+
+L'export existant **`POST /psdrf/export_dispositif_from_dendro3`** accepte désormais,
+**à la racine du payload**, deux champs optionnels (en plus des données du dispositif) :
+
+```jsonc
+{
+  "id_dispositif": 239,
+  "device": "Samsung-XCover-AB12",   // nom/identifiant de l'appareil (string, optionnel)
+  "id_role": 42,                       // utilisateur connecté (int, optionnel)
+  "cycles": [ … ],
+  "placettes": [ … ]                   // deltas created/updated/deleted (inchangé)
+}
+```
+
+Pour **chaque placette** présente dans `placettes`, la tâche insère une ligne dans
+`pr_psdrf_staging.t_dendro3_sync_log` :
+`(id_dispositif, id_placette, device, id_role, synced_at = now() UTC)`.
+
+Le résultat de la tâche d'export expose en plus `sync_log_count` (nb de lignes écrites).
+Les routes `…/export_dispositif_from_dendro3/status|result/<task_id>` sont inchangées.
+
+Table : `pr_psdrf_staging.t_dendro3_sync_log`
+`id` PK · `id_dispositif` int · `id_placette` int · `device` text · `id_role` int · `synced_at` timestamp.
+
+---
+
+## Brique 3 — État des placettes (tableau de bord multi-édition)
+
+| Méthode & chemin | Réponse |
+|---|---|
+| `GET /psdrf/dispositif-placettes-state/<int:id_dispositif>` | `200` `{ "status": "success", "data": [ … ] }` (synchrone) |
+
+Renvoie, **par placette** (le dernier log connu, le plus récent `synced_at`) :
+
+```jsonc
+{
+  "status": "success",
+  "data": [
+    {
+      "id_placette": 1024,
+      "id_dispositif": 239,
+      "device": "Samsung-XCover-AB12",
+      "id_role": 42,
+      "identifiant": "jdupont",          // identifiant de connexion (peut être null)
+      "nom_complet": "Jean Dupont",       // "prenom_role nom_role" (peut être null)
+      "synced_at": "2026-06-05T09:14:22.512000"  // ISO 8601
+    }
+  ]
+}
+```
+
+Une seule entrée par placette (la plus récente). Une placette jamais synchronisée
+en staging n'apparaît pas. Sert : signaler la propriété (« 1 mobile = 1 placette »),
+prévenir d'une multi-édition, alimenter l'écran de comparaison local ↔ staging.
+
+---
+
+## Écarts de format Brique 1 vs `/dispositif-complet`
+
+1. **Aucun écart structurel** : mêmes clés à tous les niveaux. Les modèles prod
+   (`pr_psdrf`) et staging (`pr_psdrf_staging`) sont des miroirs colonne à colonne,
+   et la sortie part toujours du dict prod (on n'y réinjecte que des clés déjà
+   présentes).
+2. **Format de date `updated_at` sur entités issues du staging** : le schéma
+   staging des arbres sérialise `updated_at` en `"%Y-%m-%d %H:%M:%S"` (via
+   `CustomDateTimeField`), là où le schéma prod émet de l'ISO 8601. Une entité
+   éditée en staging ressort donc avec ce format sur `updated_at`. (Clé identique,
+   seule la *valeur* diffère.)
+3. **Suppressions non matérialisées** : la fonction d'import staging supprime la
+   ligne staging sans tombstone. La fusion est donc **prod ∪ staging-override** :
+   une entité supprimée sur le terrain mais encore présente en prod **ressort en
+   version prod**. La résolution fine (et les suppressions) se fait **côté app**
+   (comparaison local ↔ staging), conformément au cahier des charges.
+
+---
+
+## Tests
+
+- **Brique 1 (logique de fusion)** — testée hors BDD :
+  ```bash
+  # voir le script de validation joint au commit (override, prod-only,
+  # staging-only, nested, identité sans staging) — tous verts.
+  ```
+- **Brique 1 (chaîne web)** : sur un dispositif avec saisies staging, comparer
+  `…/dispositif-complet-staging/result` à `…/dispositif-complet/result` ; vérifier
+  qu'une entité modifiée en staging ressort en version staging, les autres en prod ;
+  dispositif sans staging ⇒ identique à prod.
+- **Brique 2** : `POST /export_dispositif_from_dendro3` avec `device` + `id_role`
+  ⇒ une ligne par placette dans `t_dendro3_sync_log`.
+- **Brique 3** : `GET /dispositif-placettes-state/<id>` ⇒ dernier
+  appareil/utilisateur/horodatage par placette, cohérents avec le log.


### PR DESCRIPTION
## Contexte

Support backend GeoNature pour l'application mobile terrain **dendro3** : enregistrement de l'app et synchro descendante des saisies terrain vers le schéma staging (reprise de saisie).

## Contenu (2 commits)

### `022b0c7` — Migration : enregistrement de l'app mobile dendro3
- Migration `a1b2c3d4e5f6` : insère dendro3 dans `gn_commons.t_mobile_apps` (source unique de vérité version/APK).
- Idempotente (`INSERT … ON CONFLICT (app_code) DO UPDATE`) — sans risque si la ligne a déjà été créée manuellement en prod.

### `f857c09` — Synchro dendro3 ↔ staging
- **Pull fusionné prod + staging** : `GET /psdrf/dispositif-complet-staging/<id>` (+ status/result async), tâche `fetch_dispositif_data_merged` + `merge_prod_staging.py` (staging écrase prod, format identique à `/dispositif-complet`).
- **Traçabilité** : table `pr_psdrf_staging.t_dendro3_sync_log` (migration `b2c3d4e5f6a7`, `down_revision = a1b2c3d4e5f6`) — une ligne par placette (device / id_role).
- **État des placettes** : `GET /psdrf/dispositif-placettes-state/<id>` (dernier appareil/utilisateur/horodatage).
- Routes et tâches existantes inchangées. Contrat détaillé : `docs/dendro3-sync-staging.md`.

## Chaîne de migrations
```
2115ba146beb  (déjà en prod)
  └─ a1b2c3d4e5f6  register dendro3 mobile app
       └─ b2c3d4e5f6a7  create t_dendro3_sync_log
```
Déploiement : `geonature db upgrade psdrf@head`.

## Hors périmètre
- Ne touche pas au chemin de génération du carnet (`db_to_campagne` / `run_pipeline` / `psdrf_calculs`).
- Version du module inchangée (`0.2.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)